### PR TITLE
Calculate user's available(sendable) balance

### DIFF
--- a/Wei/View/Send/SelectAmount/BalanceAccessoryView.swift
+++ b/Wei/View/Send/SelectAmount/BalanceAccessoryView.swift
@@ -17,16 +17,16 @@ final class BalanceAccessoryView: UIView, InputAppliable {
     @IBOutlet private weak var txFeeLabel: UILabel!
 
     enum Input {
-        case balance(String)
-        case txFee(String)
+        case balance(Int64)
+        case txFee(Int64)
     }
     
     func apply(input: Input) {
         switch input {
         case .balance(let text):
-            balanceLabel.text = text
+            balanceLabel.text = String(text)
         case .txFee(let text):
-            txFeeLabel.text = text
+            txFeeLabel.text = String(text)
         }
     }
 }

--- a/Wei/View/Send/SelectAmount/SelectAmountViewController.swift
+++ b/Wei/View/Send/SelectAmount/SelectAmountViewController.swift
@@ -60,6 +60,7 @@ final class SelectAmountViewController: UIViewController {
         
         output
             .fiatAmount
+            .map(String.init)
             .drive(amountTextField.rx.text)
             .disposed(by: disposeBag)
         

--- a/Wei/View/Send/SelectAmount/SelectAmountViewModel.swift
+++ b/Wei/View/Send/SelectAmount/SelectAmountViewModel.swift
@@ -58,12 +58,14 @@ final class SelectAmountViewModel: InjectableViewModel {
         }
         
         // stripe the decimal amount from tx fee.
-        let fiatTxFee = fiatTxFeeAction.elements
-            // only use number before the decimal poin.
-            // for exsample 1 for 1.2345
-            .map { String($0.price.split(separator: ".").first ?? "") }
-            // will never fail here
-            .map { Int64($0)! }
+        // only use number before the decimal poin.
+        // for example 1 for 1.2345
+        let fiatTxFee = fiatTxFeeAction.elements.flatMap { price -> Driver<Int64> in
+            guard let doubleValue = Double(price.price), let ceiledValue = ceil(doubleValue) else {
+                return .empty()
+            }
+            return Int64(ceiledValue)!
+        }
         
         // User's total fiat balance
         let fiatBalance = balanceStore.fiatBalance.asDriver(onErrorDriveWith: .empty()).flatMap { balanceString -> Driver<Int64> in

--- a/Wei/View/Send/SelectAmount/SelectAmountViewModel.swift
+++ b/Wei/View/Send/SelectAmount/SelectAmountViewModel.swift
@@ -61,10 +61,10 @@ final class SelectAmountViewModel: InjectableViewModel {
         // only use number before the decimal poin.
         // for example 1 for 1.2345
         let fiatTxFee = fiatTxFeeAction.elements.flatMap { price -> Driver<Int64> in
-            guard let doubleValue = Double(price.price), let ceiledValue = ceil(doubleValue) else {
+            guard let doubleValue = Double(price.price) else {
                 return .empty()
             }
-            return Int64(ceiledValue)!
+            return Int64(ceil(doubleValue))!
         }
         
         // User's total fiat balance

--- a/Wei/View/Send/SelectAmount/SelectAmountViewModel.swift
+++ b/Wei/View/Send/SelectAmount/SelectAmountViewModel.swift
@@ -59,12 +59,12 @@ final class SelectAmountViewModel: InjectableViewModel {
         
         // stripe the decimal amount from tx fee.
         // only use number before the decimal poin.
-        // for example 1 for 1.2345
+        // for example 2 for 1.2345
         let fiatTxFee = fiatTxFeeAction.elements.flatMap { price -> Driver<Int64> in
             guard let doubleValue = Double(price.price) else {
                 return .empty()
             }
-            return Int64(ceil(doubleValue))!
+            return Driver.just(Int64(ceil(doubleValue)))
         }
         
         // User's total fiat balance


### PR DESCRIPTION
## Overview
it was possible for users to input users' entire amount to send but the node returns error because (sending amount - txFee) is not greater than their balance.

## Changes
- set the limit (their balance - txFee) for users to input how much they can input when sending