### PR TITLE
Add NonceManager to handle nonce management

### DIFF
--- a/Wei.xcodeproj/project.pbxproj
+++ b/Wei.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		AEFA44FB20B318C100844D4A /* RestoreWalletViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AEFA44FA20B318C100844D4A /* RestoreWalletViewController.storyboard */; };
 		AEFA44FD20B318D100844D4A /* RestoreWalletViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFA44FC20B318D100844D4A /* RestoreWalletViewController.swift */; };
 		AEFA450020B31BE500844D4A /* RestoreWalletViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFA44FF20B31BE500844D4A /* RestoreWalletViewModel.swift */; };
+		AEFE581220C7C07B00CE47F8 /* NonceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFE581120C7C07B00CE47F8 /* NonceManager.swift */; };
 		DE02317C209169AC00508B5B /* UINotificationFeedbackGenerator+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE02317B209169AC00508B5B /* UINotificationFeedbackGenerator+Extension.swift */; };
 		DE02317F2091711900508B5B /* MaintenanceViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DE02317E2091711900508B5B /* MaintenanceViewController.storyboard */; };
 		DE0231812091712700508B5B /* MaintenanceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0231802091712700508B5B /* MaintenanceViewController.swift */; };
@@ -286,6 +287,7 @@
 		AEFA44FA20B318C100844D4A /* RestoreWalletViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RestoreWalletViewController.storyboard; sourceTree = "<group>"; };
 		AEFA44FC20B318D100844D4A /* RestoreWalletViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreWalletViewController.swift; sourceTree = "<group>"; };
 		AEFA44FF20B31BE500844D4A /* RestoreWalletViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreWalletViewModel.swift; sourceTree = "<group>"; };
+		AEFE581120C7C07B00CE47F8 /* NonceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonceManager.swift; sourceTree = "<group>"; };
 		D86A64040CB267923480718A /* Pods-Wei.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Wei.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Wei/Pods-Wei.debug.xcconfig"; sourceTree = "<group>"; };
 		DE02317B209169AC00508B5B /* UINotificationFeedbackGenerator+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINotificationFeedbackGenerator+Extension.swift"; sourceTree = "<group>"; };
 		DE02317E2091711900508B5B /* MaintenanceViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MaintenanceViewController.storyboard; sourceTree = "<group>"; };
@@ -527,6 +529,7 @@
 				DE318DE220915BAD008FA01E /* BalanceStore.swift */,
 				DE318DE420916626008FA01E /* Formatter.swift */,
 				1A51790B20B50FEE00D642D3 /* EmptyViewManager.swift */,
+				AEFE581120C7C07B00CE47F8 /* NonceManager.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -1170,6 +1173,7 @@
 				DE7682EA207F4AFD004094BA /* TransactionHistoryViewController.swift in Sources */,
 				AE6146622087149900A9E77A /* RegistrationService.swift in Sources */,
 				AE171B042083436400212494 /* TransactionHistoryViewCell.swift in Sources */,
+				AEFE581220C7C07B00CE47F8 /* NonceManager.swift in Sources */,
 				DE0231812091712700508B5B /* MaintenanceViewController.swift in Sources */,
 				DE3A38392084969A00AB44B0 /* BalanceAccessoryView.swift in Sources */,
 				AE3F730B207F7F6300482502 /* Price.swift in Sources */,

--- a/Wei.xcodeproj/project.pbxproj
+++ b/Wei.xcodeproj/project.pbxproj
@@ -1287,7 +1287,7 @@
 				CODE_SIGN_ENTITLEMENTS = Wei/Wei.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 0;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = JUG749AXCX;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1316,7 +1316,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0;
+				CURRENT_PROJECT_VERSION = 1;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -1453,7 +1453,7 @@
 				BUNDLE_DISPLAY_SUFFIX = "-D";
 				CODE_SIGN_ENTITLEMENTS = Wei/Wei.entitlements;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 0;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = JUG749AXCX;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1483,7 +1483,7 @@
 				CODE_SIGN_ENTITLEMENTS = Wei/Wei.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 0;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = JUG749AXCX;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1512,7 +1512,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0;
+				CURRENT_PROJECT_VERSION = 1;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -1537,7 +1537,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0;
+				CURRENT_PROJECT_VERSION = 1;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",

--- a/Wei.xcodeproj/project.pbxproj
+++ b/Wei.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		AEFA44FD20B318D100844D4A /* RestoreWalletViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFA44FC20B318D100844D4A /* RestoreWalletViewController.swift */; };
 		AEFA450020B31BE500844D4A /* RestoreWalletViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFA44FF20B31BE500844D4A /* RestoreWalletViewModel.swift */; };
 		AEFE581220C7C07B00CE47F8 /* NonceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFE581120C7C07B00CE47F8 /* NonceManager.swift */; };
+		AEFE581620C7CBC200CE47F8 /* NonceManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFE581520C7CBC200CE47F8 /* NonceManagerTests.swift */; };
 		DE02317C209169AC00508B5B /* UINotificationFeedbackGenerator+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE02317B209169AC00508B5B /* UINotificationFeedbackGenerator+Extension.swift */; };
 		DE02317F2091711900508B5B /* MaintenanceViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DE02317E2091711900508B5B /* MaintenanceViewController.storyboard */; };
 		DE0231812091712700508B5B /* MaintenanceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0231802091712700508B5B /* MaintenanceViewController.swift */; };
@@ -288,6 +289,7 @@
 		AEFA44FC20B318D100844D4A /* RestoreWalletViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreWalletViewController.swift; sourceTree = "<group>"; };
 		AEFA44FF20B31BE500844D4A /* RestoreWalletViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreWalletViewModel.swift; sourceTree = "<group>"; };
 		AEFE581120C7C07B00CE47F8 /* NonceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonceManager.swift; sourceTree = "<group>"; };
+		AEFE581520C7CBC200CE47F8 /* NonceManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonceManagerTests.swift; sourceTree = "<group>"; };
 		D86A64040CB267923480718A /* Pods-Wei.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Wei.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Wei/Pods-Wei.debug.xcconfig"; sourceTree = "<group>"; };
 		DE02317B209169AC00508B5B /* UINotificationFeedbackGenerator+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINotificationFeedbackGenerator+Extension.swift"; sourceTree = "<group>"; };
 		DE02317E2091711900508B5B /* MaintenanceViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MaintenanceViewController.storyboard; sourceTree = "<group>"; };
@@ -692,6 +694,7 @@
 			isa = PBXGroup;
 			children = (
 				AE3EB62720AF05D900D61CE6 /* KeychainStoreTests.swift */,
+				AEFE581520C7CBC200CE47F8 /* NonceManagerTests.swift */,
 				AED6F45B205514BB004A280F /* Info.plist */,
 			);
 			path = WeiTests;
@@ -1196,6 +1199,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AE3EB62820AF05D900D61CE6 /* KeychainStoreTests.swift in Sources */,
+				AEFE581620C7CBC200CE47F8 /* NonceManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Wei/Info.plist
+++ b/Wei/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>0</string>
+	<string>1</string>
     <key>Fabric</key>
     <dict>
         <key>APIKey</key>

--- a/Wei/Utility/NonceManager.swift
+++ b/Wei/Utility/NonceManager.swift
@@ -1,0 +1,33 @@
+//
+//  NonceManager.swift
+//  Wei
+//
+//  Created by Ryo Fukuda on 2018/06/06.
+//  Copyright © 2018 yz. All rights reserved.
+//
+
+import Foundation
+
+struct NonceManager {
+    
+    /// Represents a nonce value used in the last transction
+    static var lastNonce: Int?
+    
+    /// Manage a nonce value with both fetched nonce snd last nonce
+    static func manage(_ fetchedNonce: Int) -> Int {
+        guard let storedNonce = lastNonce else {
+            lastNonce = fetchedNonce
+            return fetchedNonce
+        }
+        
+        let incrementedNonce = storedNonce + 1
+        
+        guard incrementedNonce < fetchedNonce else {
+            lastNonce = fetchedNonce
+            return fetchedNonce
+        }
+        
+        lastNonce = incrementedNonce
+        return incrementedNonce
+    }
+}

--- a/Wei/Utility/NonceManager.swift
+++ b/Wei/Utility/NonceManager.swift
@@ -13,7 +13,7 @@ struct NonceManager {
     /// Represents a nonce value used in the last transction
     static var lastNonce: Int?
     
-    /// Manage a nonce value with both fetched nonce snd last nonce
+    /// Manage a nonce value with both fetched nonce and last nonce
     static func manage(_ fetchedNonce: Int) -> Int {
         let nonce: Int
         if let storedNonce = lastNonce {

--- a/Wei/Utility/NonceManager.swift
+++ b/Wei/Utility/NonceManager.swift
@@ -15,19 +15,13 @@ struct NonceManager {
     
     /// Manage a nonce value with both fetched nonce snd last nonce
     static func manage(_ fetchedNonce: Int) -> Int {
-        guard let storedNonce = lastNonce else {
-            lastNonce = fetchedNonce
-            return fetchedNonce
+        let nonce: Int
+        if let storedNonce = lastNonce {
+            nonce = storedNonce < fetchedNonce ? fetchedNonce : storedNonce + 1
+        } else {
+            nonce = fetchedNonce
         }
-        
-        let incrementedNonce = storedNonce + 1
-        
-        guard incrementedNonce < fetchedNonce else {
-            lastNonce = fetchedNonce
-            return fetchedNonce
-        }
-        
-        lastNonce = incrementedNonce
-        return incrementedNonce
+        lastNonce = nonce
+        return nonce
     }
 }

--- a/Wei/View/Send/SendConfirmation/SendConfirmationViewModel.swift
+++ b/Wei/View/Send/SendConfirmation/SendConfirmationViewModel.swift
@@ -54,6 +54,9 @@ final class SendConfirmationViewModel: InjectableViewModel {
             
             let address = weakSelf.walletManager.address()
             let nonce = weakSelf.gethRepository.getTransactionCount(address: address, blockParameter: .pending).asObservable()
+                // NonceManager.manage manages the nonce value because sending ether constantly cases
+                // the not-increment nonce value problem.
+                .map(NonceManager.manage)
             
             let signTransaction = nonce.flatMap { nonce -> Observable<String> in
                 let wei = Converter.toWei(ether: transactionContext.etherAmount.ether()).asString(withBase: 10)

--- a/WeiTests/Info.plist
+++ b/WeiTests/Info.plist
@@ -17,8 +17,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>0</string>
+	<string>1</string>
 </dict>
 </plist>

--- a/WeiTests/NonceManagerTests.swift
+++ b/WeiTests/NonceManagerTests.swift
@@ -1,0 +1,61 @@
+//
+//  NonceManagerTests.swift
+//  WeiTests
+//
+//  Created by Ryo Fukuda on 2018/06/06.
+//  Copyright © 2018 yz. All rights reserved.
+//
+
+import Quick
+import Nimble
+@testable import Wei
+
+final class NonceManagerTests: QuickSpec {
+    
+    override func spec() {
+        describe("Test NonceManager") {
+            context("Test when just incrementing the nonce value") {
+                beforeEach {
+                    NonceManager.lastNonce = nil
+                }
+                
+                it("will just be incremented") {
+                    expect(NonceManager.manage(0))
+                        .to(equal(0))
+                    
+                    expect(NonceManager.manage(1))
+                        .to(equal(1))
+                    
+                    expect(NonceManager.manage(2))
+                        .to(equal(2))
+                    
+                    expect(NonceManager.manage(3))
+                        .to(equal(3))
+                }
+            }
+            
+            context("Test when sending ether constantly and nonce does not get updated") {
+                beforeEach {
+                    NonceManager.lastNonce = nil
+                }
+                
+                it("will increment the nonce value using lastNonce") {
+                    expect(NonceManager.manage(20))
+                        .to(equal(20))
+                    
+                    expect(NonceManager.manage(20))
+                        .to(equal(21))
+                    
+                    expect(NonceManager.manage(20))
+                        .to(equal(22))
+                    
+                    expect(NonceManager.manage(20))
+                        .to(equal(23))
+                    
+                    expect(NonceManager.manage(24))
+                        .to(equal(24))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Overview
When you try to send transactions continuously, you get the same nonce from the node because the sent transactions are not yet included in the block. to prevent error caused by the nonce value, manage nonce value locally too.

## Changes
- Added Nonce manager to manage the nonce value after the first fetch from the node