### PR TITLE
Workaround for a bug in Locale.preferedLanguages

### DIFF
--- a/Wei.xcodeproj/project.pbxproj
+++ b/Wei.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		AE3F7306207E791100482502 /* SwipableViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AE3F7305207E791100482502 /* SwipableViewController.storyboard */; };
 		AE3F7309207F7ECA00482502 /* Currency.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3F7308207F7ECA00482502 /* Currency.swift */; };
 		AE3F730B207F7F6300482502 /* Price.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3F730A207F7F6300482502 /* Price.swift */; };
+		AE43C3A220D0E45A0050BDDE /* Locale.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE43C3A120D0E45A0050BDDE /* Locale.swift */; };
 		AE6146622087149900A9E77A /* RegistrationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6146612087149900A9E77A /* RegistrationService.swift */; };
 		AE6146642087154800A9E77A /* RegistrationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6146632087154800A9E77A /* RegistrationRepository.swift */; };
 		AE61466820871B5600A9E77A /* DeviceChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE61466720871B5600A9E77A /* DeviceChecker.swift */; };
@@ -272,6 +273,7 @@
 		AE3F7305207E791100482502 /* SwipableViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SwipableViewController.storyboard; sourceTree = "<group>"; };
 		AE3F7308207F7ECA00482502 /* Currency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Currency.swift; sourceTree = "<group>"; };
 		AE3F730A207F7F6300482502 /* Price.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Price.swift; sourceTree = "<group>"; };
+		AE43C3A120D0E45A0050BDDE /* Locale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locale.swift; sourceTree = "<group>"; };
 		AE6146612087149900A9E77A /* RegistrationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationService.swift; sourceTree = "<group>"; };
 		AE6146632087154800A9E77A /* RegistrationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationRepository.swift; sourceTree = "<group>"; };
 		AE61466720871B5600A9E77A /* DeviceChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceChecker.swift; sourceTree = "<group>"; };
@@ -406,6 +408,7 @@
 				AE3EB5FE20A83A9000D61CE6 /* Gas.swift */,
 				DE9133C520AEFE78003CDE67 /* MnemonicWord.swift */,
 				AEC36AE020C58A9800FE4737 /* LocalTransaction.swift */,
+				AE43C3A120D0E45A0050BDDE /* Locale.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1120,6 +1123,7 @@
 				AED6F491205525DC004A280F /* RootViewController.swift in Sources */,
 				DE91338E20A03B39003CDE67 /* UIDevice+WeiExtension.swift in Sources */,
 				1A798C162081F23600812D80 /* DateFormatter.swift in Sources */,
+				AE43C3A220D0E45A0050BDDE /* Locale.swift in Sources */,
 				1A798C032081DE7200812D80 /* LatestTransactionListViewCell.swift in Sources */,
 				AE1F8C252090B3F10088A043 /* AlertConvertable.swift in Sources */,
 				1A3BD8FD205C0FBF00FE485D /* WalletManager.swift in Sources */,

--- a/Wei/Model/Locale.swift
+++ b/Wei/Model/Locale.swift
@@ -1,0 +1,28 @@
+//
+//  Locale.swift
+//  Wei
+//
+//  Created by Ryo Fukuda on 2018/06/13.
+//  Copyright © 2018 yz. All rights reserved.
+//
+
+import Foundation
+
+enum Locale {
+    case ja
+    case en
+    
+    static func preferred() -> Locale {
+        // NOTE: Locale.preferredLanguages() returns ja, ja-JP, or ja-US.
+        guard let preferred = Foundation.Locale.preferredLanguages[0].split(separator: "-").first else {
+            return .en
+        }
+        
+        switch preferred {
+        case "ja":
+            return .ja
+        default:
+            return .en
+        }
+    }
+}

--- a/Wei/Utility/MnemonicManager.swift
+++ b/Wei/Utility/MnemonicManager.swift
@@ -18,10 +18,10 @@ final class MnemonicManager: MnemonicManagerProtocol {
     private let language: WordList
     
     init() {
-        switch Locale.preferredLanguages[0] {
-        case "ja-JP":
+        switch Locale.preferred() {
+        case .ja:
             self.language = .japanese
-        default:
+        case .en:
             self.language = .english
         }
     }


### PR DESCRIPTION
## Overview
When using devices in Japanese, `Locale.preferedLanguages` returns one of `ja`, `ja-JP`, `ja-US` randomly. This is a workaround for this bug

## Changes